### PR TITLE
Adding curl error and curl error code to Exception

### DIFF
--- a/src/TeamsConnector.php
+++ b/src/TeamsConnector.php
@@ -38,7 +38,7 @@ class TeamsConnector
         $result = curl_exec($ch);
 
         if ($result !== "1") {
-            throw new \Exception($result);
+            throw new \Exception(curl_error($ch), curl_errno($ch));
         }
     }
 }


### PR DESCRIPTION
When debugging a failed curl call, it's hard to know why it failed because Teams does not send any information. 
However, to have access to the curl error code is quite helpful.