### PR TITLE
Add error message to exception

### DIFF
--- a/src/TeamsConnector.php
+++ b/src/TeamsConnector.php
@@ -37,8 +37,11 @@ class TeamsConnector
 
         $result = curl_exec($ch);
 
-        if ($result !== "1") {
+        if (curl_error($ch)) {
             throw new \Exception(curl_error($ch), curl_errno($ch));
+        }
+        if ($result !== "1") {
+            throw new \Exception('Error response: ' $result);
         }
     }
 }

--- a/src/TeamsConnector.php
+++ b/src/TeamsConnector.php
@@ -41,7 +41,7 @@ class TeamsConnector
             throw new \Exception(curl_error($ch), curl_errno($ch));
         }
         if ($result !== "1") {
-            throw new \Exception('Error response: ' $result);
+            throw new \Exception('Error response: ' . $result);
         }
     }
 }


### PR DESCRIPTION
When Teams responds with something that is not "1" there is no curl error, so those errors need different handling

```Webhook message delivery failed with error: Microsoft Teams endpoint returned HTTP error 413 with ContextId tcid.......etcetera``` is what you get back when the payload is too large. Why on earth MS choses to respond with 200 OK, instead of using the 413 as http statuscode instead of putting it in the 200 OK body beats me. But showing the error helps debugging