### PR TITLE
Fix type hint for title and text arguments

### DIFF
--- a/src/Cards/CustomCard.php
+++ b/src/Cards/CustomCard.php
@@ -47,8 +47,8 @@ class CustomCard implements TeamsConnectorInterface
 
     /**
      * CustomCard constructor.
-     * @param null $title
-     * @param null $text
+     * @param string|null $title
+     * @param string|null $text
      */
     public function __construct($title = null, $text = null)
     {


### PR DESCRIPTION
This was giving issues with static analysis in consuming codebases