### PR TITLE
fix: correct type of verson in CustomAdaptiveCard

### DIFF
--- a/src/Cards/Adaptive/CustomAdaptiveCard.php
+++ b/src/Cards/Adaptive/CustomAdaptiveCard.php
@@ -71,7 +71,7 @@ class CustomAdaptiveCard extends Card
             "content" => [
                 "\$schema" => "http://adaptivecards.io/schemas/adaptive-card.json",
                 "type" => "AdaptiveCard",
-                "version" => $this->version,
+                "version" => (string) $this->version,
             ],
         ];
 

--- a/src/TeamsConnector.php
+++ b/src/TeamsConnector.php
@@ -42,7 +42,7 @@ class TeamsConnector
         if (curl_error($ch)) {
             throw new \Exception(curl_error($ch), curl_errno($ch));
         }
-        if ($result !== "1") {
+        if ($result !== "1" && $result !== "") {
             throw new \Exception('Error response: ' . $result);
         }
     }


### PR DESCRIPTION
Version must be a string otherwise, M$ will answer with an exception.
Additionally, the new workflow will result with empty string instead of "1".