### PR TITLE
fix selectAction content when sending it over the teamsconnector

### DIFF
--- a/src/Cards/Adaptive/Elements/Image.php
+++ b/src/Cards/Adaptive/Elements/Image.php
@@ -2,6 +2,8 @@
 
 namespace Sebbmyr\Teams\Cards\Adaptive\Elements;
 
+use Sebbmyr\Teams\Cards\Adaptive\Actions\AdaptiveCardAction;
+
 /**
  * Image element
  *
@@ -65,7 +67,7 @@ class Image extends BaseElement implements AdaptiveCardElement
      * Type: ISelectAction
      * Required: no
      * @version 1.1
-     * @var string
+     * @var AdaptiveCardAction
      */
     private $selectAction;
 
@@ -135,7 +137,7 @@ class Image extends BaseElement implements AdaptiveCardElement
         }
 
         if (isset($this->selectAction) && $version >= 1.1) {
-            $element["selectAction"] = $this->selectAction;
+            $element["selectAction"] = $this->selectAction->getContent($version);
         }
 
         if (isset($this->size) && $version >= 1.0) {
@@ -244,6 +246,18 @@ class Image extends BaseElement implements AdaptiveCardElement
     public function setWidth($width)
     {
         $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * Sets SelectAction. Available options can be found in Cards/Adaptive/Actions
+     * @param AdaptiveCardAction $selectAction
+     * @return Image
+     */
+    public function setSelectAction(AdaptiveCardAction $selectAction)
+    {
+        $this->selectAction = $selectAction;
 
         return $this;
     }

--- a/src/Cards/Adaptive/Elements/TextRun.php
+++ b/src/Cards/Adaptive/Elements/TextRun.php
@@ -272,7 +272,7 @@ class TextRun implements AdaptiveCardElement
 
     /**
      * Sets SelectAction. Available options can be found in Cards/Adaptive/Actions
-     * @param string $selectAction
+     * @param AdaptiveCardAction $selectAction
      * @return TextRun
      */
     public function setSelectAction(AdaptiveCardAction $selectAction)

--- a/src/Cards/Adaptive/Elements/TextRun.php
+++ b/src/Cards/Adaptive/Elements/TextRun.php
@@ -271,7 +271,7 @@ class TextRun implements AdaptiveCardElement
     }
 
     /**
-     * Sets SelectAction. Available options can be found in Cards/Adaptive/Actions.php
+     * Sets SelectAction. Available options can be found in Cards/Adaptive/Actions
      * @param string $selectAction
      * @return TextRun
      */

--- a/src/Cards/Adaptive/Elements/TextRun.php
+++ b/src/Cards/Adaptive/Elements/TextRun.php
@@ -164,7 +164,7 @@ class TextRun implements AdaptiveCardElement
         }
 
         if (isset($this->selectAction) && $version >= 1.2) {
-            $element["selectAction"] = $this->selectAction;
+            $element["selectAction"] = $this->selectAction->getContent($version);
         }
 
         if (isset($this->size) && $version >= 1.2) {

--- a/src/Cards/Adaptive/Elements/TextRun.php
+++ b/src/Cards/Adaptive/Elements/TextRun.php
@@ -79,7 +79,7 @@ class TextRun implements AdaptiveCardElement
      * Type: ISelectAction
      * Required: no
      * @version 1.2
-     * @var string
+     * @var AdaptiveCardAction
      */
     private $selectAction;
 


### PR DESCRIPTION
without the getContent($version) call, `{}` would be sent if the selectAction was set on the object.